### PR TITLE
fix broken links in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,11 +24,11 @@ rigorous as to become inaccessible.
 
 ## Language
 
-- [rationale.md] Rationale
+- [Rationale](rationale.md)
 - (specification - TODO)
 
 ## Implementation
 
 ### Understanding
 
-- [using_the_interpreter.md]Using the interactive interpreter
+- [Using the interactive interpreter](using_the_interpreter.md)


### PR DESCRIPTION
This changes fixes two broken markdown links inside the documentation.