### PR TITLE
Replace errors.Join with multierr.Combine to let the repo be used with go 1.18

### DIFF
--- a/analysis/validation.go
+++ b/analysis/validation.go
@@ -17,11 +17,11 @@
 package analysis
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
+	"go.uber.org/multierr"
 	"github.com/google/mangle/ast"
 	"github.com/google/mangle/builtin"
 	"github.com/google/mangle/functional"
@@ -237,7 +237,7 @@ func (a *Analyzer) Analyze(program []ast.Clause) (*ProgramInfo, error) {
 	for p, d := range a.decl {
 		globalDecls[p] = d
 		if errs := CheckDecl(d); errs != nil {
-			return nil, errors.Join(errs...)
+			return nil, multierr.Combine(errs...)
 		}
 	}
 	desugaredDecls, err := symbols.CheckAndDesugar(globalDecls)


### PR DESCRIPTION
This is the only place that's using `errors.Join`, while the rest of the code seems to rely on `multierr.Combine`.

The reason of this proposed change is that with `errors.Join` it's not possible to build/use the package with go `1.18`. After the change, it starts to work.

`go.mod` still requires golang version `1.20`, but it seems to work for my case anyway.

Please let me know what you think, thanks!