### PR TITLE
Fixes #25: Add check for duplicate declarations

### DIFF
--- a/analysis/validation.go
+++ b/analysis/validation.go
@@ -166,6 +166,9 @@ func New(extraPredicates map[ast.PredicateSym]ast.Decl, decls []ast.Decl, bounds
 		if pred == symbols.Package || pred == symbols.Use {
 			continue
 		}
+		if existing, ok := declMap[pred]; ok {
+			return nil, fmt.Errorf("predicate %v declared more than once, previous was %v", pred, existing)
+		}
 		declMap[pred] = decl
 
 		if extraDecl, ok := extraByName[pred.Symbol]; ok {

--- a/analysis/validation_test.go
+++ b/analysis/validation_test.go
@@ -531,6 +531,18 @@ func TestAnalyzeNegative(t *testing.T) {
 			t.Errorf("%q: expected error for invalid program %v", test.descr, test.program)
 		}
 	}
+
+	// Test case for duplicate declarations across different source units.
+	fooDecl = makeSyntheticDecl(t, atom("foo(X,Y)"))
+	decls1 := []ast.Decl{fooDecl}
+	decls2 := []ast.Decl{fooDecl}
+	program := []parse.SourceUnit{
+		{Decls: decls1},
+		{Decls: decls2},
+	}
+	if _, err := Analyze(program, nil); err == nil {
+		t.Errorf("expected error for duplicate decls in different units but got none")
+	}
 }
 
 func makeRulesMap(clauses []ast.Clause) map[ast.PredicateSym][]ast.Clause {

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	bitbucket.org/creachadair/stringset v0.0.11
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/chzyer/readline v1.5.1
-	github.com/golang/glog v1.2.4
+	github.com/golang/glog v1.2.5
 	github.com/google/go-cmp v0.6.0
 	go.uber.org/multierr v1.11.0
-	google.golang.org/protobuf v1.34.0
+	google.golang.org/protobuf v1.36.9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -3,9 +3,12 @@ bitbucket.org/creachadair/stringset v0.0.11/go.mod h1:wh0BHewFe+j0HrzWz7KcGbSNpF
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
+github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
+github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -14,5 +17,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 golang.org/x/exp v0.0.0-20240707233637-46b078467d37 h1:uLDX+AfeFCct3a2C7uIWBKMJIR3CJMhcgfrUAqjRK6w=
 golang.org/x/exp v0.0.0-20240707233637-46b078467d37/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 google.golang.org/protobuf v1.34.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
+google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=


### PR DESCRIPTION
This PR implements error reporting when there are multiple type declarations 
          in a program, addressing the issue where duplicate declarations were silently 
          overwriting each other.