### PR TITLE
Add test case for issue #25: duplicate declarations should report error

### DIFF
--- a/analysis/test_cases/neg_duplicate_decl.mg
+++ b/analysis/test_cases/neg_duplicate_decl.mg
@@ -1,0 +1,8 @@
+# Test case for issue #25 - duplicate declarations should cause an error
+
+Decl foo(X, Y, Z) descr [ extensional() ] bound [/x, /y, /z].
+
+# This should cause an error - duplicate declaration
+Decl foo(X, Y, Z) descr [ extensional() ].
+
+foo(1, 2, 3).


### PR DESCRIPTION
- Test includes two declarations of the same predicate foo/3
- Expected behavior: analysis should report error for duplicate declarations

Addresses: https://github.com/google/mangle/issues/25